### PR TITLE
Version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,19 +54,19 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.7.0</version>
+      <version>3.11.0</version>
     </dependency>
     <!-- Used to extract and update S3 file -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.11.979</version>
+      <version>1.12.253</version>
     </dependency>
     <!-- Need this so that lambda log will be shown in CloudWatch -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-log4j2</artifactId>
-      <version>1.2.0</version>
+      <version>1.5.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
@@ -82,70 +82,70 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.14.1</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.14.1</version>
+      <version>2.18.0</version>
     </dependency>
     <!-- used to perform serialisation -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.2</version>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-modules-java8</artifactId>
-      <version>2.12.2</version>
+      <version>2.13.3</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.12.2</version>
+      <version>2.13.3</version>
     </dependency>
     <!-- Need to read the database-->
     <dependency>
       <groupId>com.github.francis-pang</groupId>
       <artifactId>expense-tally-expense-manager</artifactId>
-      <version>72</version>
+      <version>75</version>
     </dependency>
     <dependency>
       <groupId>com.github.francis-pang</groupId>
       <artifactId>expense-tally-reconciliator</artifactId>
-      <version>72</version>
+      <version>75</version>
     </dependency>
     <dependency>
       <groupId>com.github.francis-pang</groupId>
       <artifactId>expense-tally-csv-parser</artifactId>
-      <version>72</version>
+      <version>75</version>
     </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.8.0-M1</version>
+      <version>5.9.0-M1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>3.8.0</version>
+      <version>4.6.1</version>
       <scope>test</scope>
     </dependency>
     <!-- This allows us to mock final class-->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>3.8.0</version>
+      <version>4.6.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.19.0</version>
+      <version>3.23.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Updated com.amazonaws:aws-lambda-java-events:jar:3.7.0 to version 3.11.0
Updated com.amazonaws:aws-java-sdk-s3:jar:1.11.979 to version 1.12.253
Updated com.amazonaws:aws-lambda-java-log4j2:jar:1.2.0 to version 1.5.1
Updated org.apache.logging.log4j:log4j-core:jar:2.14.1 to version 2.18.0
Updated org.apache.logging.log4j:log4j-api:jar:2.14.1 to version 2.18.0
Updated com.fasterxml.jackson.core:jackson-databind:jar:2.12.2 to version 2.13.3
Updated com.fasterxml.jackson.module:jackson-modules-java8:pom:2.12.2 to version 2.13.3
Updated com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.12.2 to version 2.13.3
Updated com.github.francis-pang:expense-tally-expense-manager:jar:72 to version 75
Updated com.github.francis-pang:expense-tally-reconciliator:jar:72 to version 75
Updated com.github.francis-pang:expense-tally-csv-parser:jar:72 to version 75
Updated org.junit.jupiter:junit-jupiter-api:jar:5.8.0-M1 to version 5.9.0-M1
Updated org.mockito:mockito-junit-jupiter:jar:3.8.0 to version 4.6.1
Updated org.mockito:mockito-inline:jar:3.8.0 to version 4.6.1
Updated org.assertj:assertj-core:jar:3.19.0 to version 3.23.1